### PR TITLE
Add discount feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ReceiptWiser is a web application that allows users to scan receipts, analyze th
 - **Receipt Scanning**: Upload images of receipts for automatic analysis
 - **AI-Powered Analysis**: Uses OpenAI's Vision API to extract items, quantities, prices, and tax information
 - **Interactive Editor**: Edit extracted receipt data, add/remove items, and adjust prices
+- **Discount Handling**: Apply a discount percentage to the entire receipt
 - **Shareable Links**: Generate and share links containing receipt data with friends
 - **Bill Splitting**: Recipients can select their items and see their portion of the bill
 - **Responsive Design**: Works on both desktop and mobile devices
@@ -66,6 +67,7 @@ ReceiptWiser is a web application that allows users to scan receipts, analyze th
 3. Add new items using the "Add Item" button.
 4. Remove items using the "Delete" button next to each item.
 5. Adjust tax percentage if needed.
+6. Apply a discount percentage if the receipt includes a discount.
 
 ### Sharing with Friends
 

--- a/src/app/api/analyze-receipt/route.ts
+++ b/src/app/api/analyze-receipt/route.ts
@@ -14,6 +14,8 @@ const ReceiptItem = z.object({
 const ReceiptAnalysis = z.object({
   items: z.array(ReceiptItem),
   subtotal: z.number(),
+  discountPercent: z.number().optional().default(0),
+  discountAmount: z.number().optional().default(0),
   serviceChargePercent: z.number(),
   serviceChargeAmount: z.number(),
   taxPercent: z.number(),
@@ -117,6 +119,8 @@ export async function POST(request: Request) {
           data: {
             items: [],
             subtotal: 0,
+            discountPercent: 0,
+            discountAmount: 0,
             serviceChargePercent: 0,
             serviceChargeAmount: 0,
             taxPercent: 0,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,6 +36,8 @@ export default function Home() {
         },
       ],
       subtotal: 0,
+      discountPercent: 0,
+      discountAmount: 0,
       serviceChargePercent: 0,
       serviceChargeAmount: 0,
       taxPercent: 0,

--- a/src/app/share/[data]/page.tsx
+++ b/src/app/share/[data]/page.tsx
@@ -19,6 +19,7 @@ interface MinimalReceipt {
   i: MinimalReceiptItem[]; // items
   t: number; // total
   s: number; // subtotal
+  d: number; // discount percent
   tx: number; // tax percent
   sc: number; // service charge percent
   cn?: string; // creator name (optional)
@@ -58,19 +59,28 @@ export default function SharedReceiptPage() {
         })),
         subtotal: minimalReceipt.s,
         total: minimalReceipt.t,
-        taxPercent: minimalReceipt.tx,
+        discountPercent: minimalReceipt.d,
         serviceChargePercent: minimalReceipt.sc,
+        taxPercent: minimalReceipt.tx,
         // Calculate amounts based on percentages
-        taxAmount: Number(
-          ((minimalReceipt.tx / 100) * minimalReceipt.s).toFixed(2)
+        discountAmount: Number(
+          ((minimalReceipt.d / 100) * minimalReceipt.s).toFixed(2)
         ),
-        serviceChargeAmount: Number(
-          ((minimalReceipt.sc / 100) * minimalReceipt.s).toFixed(2)
-        ),
+        serviceChargeAmount: 0, // placeholder, updated below
+        taxAmount: 0, // placeholder, updated below
         // Add back the optional fields if they exist
         ...(minimalReceipt.cn ? { creatorName: minimalReceipt.cn } : {}),
         ...(minimalReceipt.cp ? { creatorPhone: minimalReceipt.cp } : {}),
       };
+
+      const discountedSubtotal =
+        reconstructedReceipt.subtotal - reconstructedReceipt.discountAmount;
+      reconstructedReceipt.serviceChargeAmount = Number(
+        ((reconstructedReceipt.serviceChargePercent / 100) * discountedSubtotal).toFixed(2)
+      );
+      reconstructedReceipt.taxAmount = Number(
+        ((reconstructedReceipt.taxPercent / 100) * (discountedSubtotal + reconstructedReceipt.serviceChargeAmount)).toFixed(2)
+      );
 
       setReceipt(reconstructedReceipt);
     } catch (error) {

--- a/src/components/ReceiptEditor.tsx
+++ b/src/components/ReceiptEditor.tsx
@@ -15,6 +15,9 @@ export default function ReceiptEditor({
   onChange,
 }: ReceiptEditorProps) {
   const [items, setItems] = useState<ReceiptItem[]>([]);
+  const [discountPercent, setDiscountPercent] = useState<number>(
+    receipt.discountPercent || 0
+  );
   const [serviceChargePercent, setServiceChargePercent] = useState<number>(
     receipt.serviceChargePercent || 0
   );
@@ -38,16 +41,20 @@ export default function ReceiptEditor({
     setItems(initializedItems);
   }, []);
 
-  // Calculate subtotal, service charge, tax amount, and total whenever items, service charge percent, tax percent, or creator details change
+  // Calculate subtotal, discount, service charge, tax amount, and total whenever values change
   useEffect(() => {
     const subtotal = calculateSubtotal(items);
-    const serviceChargeAmount = (subtotal * serviceChargePercent) / 100;
-    const taxAmount = ((subtotal + serviceChargeAmount) * taxPercent) / 100;
-    const total = subtotal + serviceChargeAmount + taxAmount;
+    const discountAmount = (subtotal * discountPercent) / 100;
+    const discountedSubtotal = subtotal - discountAmount;
+    const serviceChargeAmount = (discountedSubtotal * serviceChargePercent) / 100;
+    const taxAmount = ((discountedSubtotal + serviceChargeAmount) * taxPercent) / 100;
+    const total = discountedSubtotal + serviceChargeAmount + taxAmount;
 
     const updatedReceipt: Receipt = {
       items,
       subtotal,
+      discountPercent,
+      discountAmount,
       serviceChargePercent,
       serviceChargeAmount,
       taxPercent,
@@ -59,7 +66,7 @@ export default function ReceiptEditor({
     };
 
     onChange(updatedReceipt);
-  }, [items, serviceChargePercent, taxPercent, creatorName, creatorPhone]);
+  }, [items, discountPercent, serviceChargePercent, taxPercent, creatorName, creatorPhone]);
 
   // Calculate subtotal from items
   const calculateSubtotal = (items: ReceiptItem[]): number => {
@@ -254,6 +261,21 @@ export default function ReceiptEditor({
         <div className="flex justify-between items-center mb-2">
           <span>Subtotal:</span>
           <span>${receipt.subtotal.toFixed(2)}</span>
+        </div>
+
+        <div className="flex justify-between items-center mb-2">
+          <div className="flex items-center">
+            <span className="mr-2">Discount (%):</span>
+            <NumberInput
+              value={discountPercent}
+              onChange={setDiscountPercent}
+              min={0}
+              step="0.1"
+              allowDecimals={true}
+              className="w-16 p-1 border rounded"
+            />
+          </div>
+          <span>${receipt.discountAmount.toFixed(2)}</span>
         </div>
 
         <div className="flex justify-between items-center mb-2">

--- a/src/components/ReceiptUploader.tsx
+++ b/src/components/ReceiptUploader.tsx
@@ -82,6 +82,8 @@ export default function ReceiptUploader({
             items: Array.isArray(data.data.items) ? data.data.items : [],
             subtotal:
               typeof data.data.subtotal === "number" ? data.data.subtotal : 0,
+            discountPercent: 0,
+            discountAmount: 0,
             serviceChargePercent: 0, // Initialize service charge percent to 0
             serviceChargeAmount: 0, // Initialize service charge amount to 0
             taxPercent:

--- a/src/components/ReceiptViewer.tsx
+++ b/src/components/ReceiptViewer.tsx
@@ -59,6 +59,7 @@ export default function ReceiptViewer({ receipt }: ReceiptViewerProps) {
 
     // Add totals
     message += `\nSubtotal: $${userBill.subtotal.toFixed(2)}`;
+    message += `\nDiscount: -$${userBill.discountAmount.toFixed(2)}`;
     message += `\nService Charge: $${userBill.serviceChargeAmount.toFixed(2)}`;
     message += `\nTax: $${userBill.taxAmount.toFixed(2)}`;
     message += `\nTotal: $${userBill.total.toFixed(2)}`;
@@ -87,17 +88,20 @@ export default function ReceiptViewer({ receipt }: ReceiptViewerProps) {
       0
     );
 
-    // Calculate proportional service charge
-    const serviceChargeRate = receipt.serviceChargeAmount / receipt.subtotal;
-    const serviceChargeAmount = subtotal * serviceChargeRate;
+    // Apply discount proportionally
+    const discountAmount = (subtotal * receipt.discountPercent) / 100;
+    const discountedSubtotal = subtotal - discountAmount;
 
-    // Calculate proportional tax (applied to subtotal + service charge)
-    const taxBase = receipt.subtotal + receipt.serviceChargeAmount;
-    const taxRate = receipt.taxAmount / taxBase;
-    const taxAmount = (subtotal + serviceChargeAmount) * taxRate;
+    // Calculate service charge based on discounted subtotal
+    const serviceChargeAmount =
+      (discountedSubtotal * receipt.serviceChargePercent) / 100;
+
+    // Calculate tax (applied to discounted subtotal + service charge)
+    const taxAmount =
+      ((discountedSubtotal + serviceChargeAmount) * receipt.taxPercent) / 100;
 
     // Calculate total
-    const total = subtotal + serviceChargeAmount + taxAmount;
+    const total = discountedSubtotal + serviceChargeAmount + taxAmount;
 
     // Create user bill
     const bill: UserBill = {
@@ -106,6 +110,7 @@ export default function ReceiptViewer({ receipt }: ReceiptViewerProps) {
         selectedQuantity: quantity,
       })),
       subtotal,
+      discountAmount,
       serviceChargeAmount,
       taxAmount,
       total,
@@ -196,15 +201,20 @@ export default function ReceiptViewer({ receipt }: ReceiptViewerProps) {
           </div>
 
           <div className="mt-4 pt-2 border-t">
-            <div className="flex justify-between items-center mb-1">
-              <span>Subtotal:</span>
-              <span>${userBill.subtotal.toFixed(2)}</span>
-            </div>
+          <div className="flex justify-between items-center mb-1">
+            <span>Subtotal:</span>
+            <span>${userBill.subtotal.toFixed(2)}</span>
+          </div>
 
-            <div className="flex justify-between items-center mb-1">
-              <span>Service Charge:</span>
-              <span>${userBill.serviceChargeAmount.toFixed(2)}</span>
-            </div>
+          <div className="flex justify-between items-center mb-1">
+            <span>Discount:</span>
+            <span>-${userBill.discountAmount.toFixed(2)}</span>
+          </div>
+
+          <div className="flex justify-between items-center mb-1">
+            <span>Service Charge:</span>
+            <span>${userBill.serviceChargeAmount.toFixed(2)}</span>
+          </div>
 
             <div className="flex justify-between items-center mb-1">
               <span>Tax:</span>

--- a/src/components/ReceiptViewer.tsx
+++ b/src/components/ReceiptViewer.tsx
@@ -201,20 +201,20 @@ export default function ReceiptViewer({ receipt }: ReceiptViewerProps) {
           </div>
 
           <div className="mt-4 pt-2 border-t">
-          <div className="flex justify-between items-center mb-1">
-            <span>Subtotal:</span>
-            <span>${userBill.subtotal.toFixed(2)}</span>
-          </div>
+            <div className="flex justify-between items-center mb-1">
+              <span>Subtotal:</span>
+              <span>${userBill.subtotal.toFixed(2)}</span>
+            </div>
 
-          <div className="flex justify-between items-center mb-1">
-            <span>Discount:</span>
-            <span>-${userBill.discountAmount.toFixed(2)}</span>
-          </div>
+            <div className="flex justify-between items-center mb-1">
+              <span>Discount:</span>
+              <span>-${userBill.discountAmount.toFixed(2)}</span>
+            </div>
 
-          <div className="flex justify-between items-center mb-1">
-            <span>Service Charge:</span>
-            <span>${userBill.serviceChargeAmount.toFixed(2)}</span>
-          </div>
+            <div className="flex justify-between items-center mb-1">
+              <span>Service Charge:</span>
+              <span>${userBill.serviceChargeAmount.toFixed(2)}</span>
+            </div>
 
             <div className="flex justify-between items-center mb-1">
               <span>Tax:</span>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -25,6 +25,7 @@ export default function ShareButton({ receipt }: ShareButtonProps) {
         // Essential totals and rates
         t: Number(receipt.total.toFixed(2)), // total
         s: Number(receipt.subtotal.toFixed(2)), // subtotal
+        d: Number(receipt.discountPercent.toFixed(2)), // discount percent
         tx: Number(receipt.taxPercent.toFixed(2)), // tax percent
         sc: Number(receipt.serviceChargePercent.toFixed(2)), // service charge percent
         // Optional creator info (only if present)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export interface ReceiptItem {
 export interface Receipt {
   items: ReceiptItem[];
   subtotal: number;
+  discountPercent: number;
+  discountAmount: number;
   serviceChargePercent: number;
   serviceChargeAmount: number;
   taxPercent: number;
@@ -31,6 +33,7 @@ export interface UserSelection {
 export interface UserBill {
   selectedItems: (ReceiptItem & { selectedQuantity: number })[];
   subtotal: number;
+  discountAmount: number;
   serviceChargeAmount: number;
   taxAmount: number;
   total: number;


### PR DESCRIPTION
## Summary
- add discount fields to types and API
- include discount in receipt creator/editor components
- show discount when viewing shared receipts
- preserve discount percent in share links and page
- document discount feature in README

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684985686d288331a9815310b4125f5c