### PR TITLE
Increase body size limit for receipts API route

### DIFF
--- a/src/app/api/receipts/route.ts
+++ b/src/app/api/receipts/route.ts
@@ -3,6 +3,14 @@ import { prisma } from "@/lib/prisma";
 import { Receipt } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "10mb",
+    },
+  },
+};
+
 export async function POST(request: NextRequest) {
   try {
     const receipt: Receipt = await request.json();


### PR DESCRIPTION
## Summary
- configure the receipts API route to accept request bodies up to 10 MB

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_6901a9de8f088331998fbc0b28ee61c5