### PR TITLE
Strip receipt image data from share API payload

### DIFF
--- a/src/app/api/receipts/route.ts
+++ b/src/app/api/receipts/route.ts
@@ -3,6 +3,14 @@ import { prisma } from "@/lib/prisma";
 import { Receipt } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "10mb",
+    },
+  },
+};
+
 export async function POST(request: NextRequest) {
   try {
     const receipt: Receipt = await request.json();

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -17,13 +17,20 @@ export default function ShareButton({ receipt }: ShareButtonProps) {
     try {
       setIsLoading(true);
 
+      // The analyzed receipt includes a data URL for the uploaded image. This
+      // makes the payload several megabytes large, which causes the API request
+      // to exceed Vercel's body size limits. Strip the image before sending the
+      // data to the backend so we only persist the structured receipt details.
+      const { imageUrl: _imageUrl, ...receiptWithoutImage } = receipt;
+      void _imageUrl;
+
       // Save receipt to database
       const response = await fetch("/api/receipts", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(receipt),
+        body: JSON.stringify(receiptWithoutImage),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- remove the embedded image from the receipt payload before posting to the receipts API to keep requests small enough for Vercel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_6901a9de8f088331998fbc0b28ee61c5